### PR TITLE
A minor fix to boolean value handling

### DIFF
--- a/insales/composing.py
+++ b/insales/composing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; -*-
 
 import datetime
-import collections
+import collections.abc
 import xml.etree.ElementTree as et
 
 from decimal import Decimal
@@ -42,12 +42,12 @@ def compose_element(key, value, arrays={}):
         e.text = value.replace(microsecond=0).isoformat()
     elif value is None:
         e.attrib['nil'] = 'true'
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections.abc.Sequence):
         e.attrib['type'] = 'array'
         e_key = arrays[key]
         for x in value:
             e.append(compose_element(e_key, x, arrays))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections.abc.Mapping):
         for key, value in value.items():
             e.append(compose_element(key, value, arrays))
     else:

--- a/insales/composing.py
+++ b/insales/composing.py
@@ -25,6 +25,9 @@ def compose_element(key, value, arrays={}):
     e = et.Element(key)
     if isinstance(value, basestring):
         e.text = value
+    elif isinstance(value, bool):
+        e.attrib['type'] = 'boolean'
+        e.text = str(value).lower()
     elif isinstance(value, (int, long)):
         e.attrib['type'] = 'integer'
         e.text = str(value)


### PR DESCRIPTION
Added couple of lines to fix problems updating boolean values, particularly, is_hidden flag.
Being a subtype of int, booleans are treated as integers in composing.py causing at least product endpoints to silently ignore it.
Would be nice to see this fix in pypl distribution.