### PR TITLE
Work with modern python, drop compatibility with ancient python

### DIFF
--- a/insales/composing.py
+++ b/insales/composing.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8; -*-
 
 import datetime
-import collections
+import collections.abc
 import xml.etree.ElementTree as et
 
 from decimal import Decimal
@@ -42,12 +42,12 @@ def compose_element(key, value, arrays={}):
         e.text = value.replace(microsecond=0).isoformat()
     elif value is None:
         e.attrib['nil'] = 'true'
-    elif isinstance(value, collections.Sequence):
+    elif isinstance(value, collections.abc.Sequence):
         e.attrib['type'] = 'array'
         e_key = arrays[key]
         for x in value:
             e.append(compose_element(e_key, x, arrays))
-    elif isinstance(value, collections.Mapping):
+    elif isinstance(value, collections.abc.Mapping):
         for key, value in value.items():
             e.append(compose_element(key, value, arrays))
     else:

--- a/insales/composing.py
+++ b/insales/composing.py
@@ -25,6 +25,9 @@ def compose_element(key, value, arrays={}):
     e = et.Element(key)
     if isinstance(value, basestring):
         e.text = value
+    elif isinstance(value, bool):
+        e.attrib['type'] = 'boolean'
+        e.text = str(value).lower()
     elif isinstance(value, (int, long)):
         e.attrib['type'] = 'integer'
         e.text = str(value)

--- a/insales/composing.py
+++ b/insales/composing.py
@@ -1,21 +1,11 @@
 # -*- coding: utf-8; -*-
 
 import datetime
-import collections.abc
 import xml.etree.ElementTree as et
 
+from collections.abc import Mapping, Sequence
 from decimal import Decimal
 
-# Python 2, 3 intercompatibility
-try:
-    basestring
-except NameError:
-    basestring = str
-
-try:
-    long
-except NameError:
-    long = int
 
 def compose(data, root, arrays={}):
     root_e = compose_element(root, data, arrays)
@@ -23,12 +13,12 @@ def compose(data, root, arrays={}):
 
 def compose_element(key, value, arrays={}):
     e = et.Element(key)
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         e.text = value
     elif isinstance(value, bool):
         e.attrib['type'] = 'boolean'
         e.text = str(value).lower()
-    elif isinstance(value, (int, long)):
+    elif isinstance(value, int):
         e.attrib['type'] = 'integer'
         e.text = str(value)
     elif isinstance(value, Decimal):
@@ -42,12 +32,12 @@ def compose_element(key, value, arrays={}):
         e.text = value.replace(microsecond=0).isoformat()
     elif value is None:
         e.attrib['nil'] = 'true'
-    elif isinstance(value, collections.abc.Sequence):
+    elif isinstance(value, Sequence):
         e.attrib['type'] = 'array'
         e_key = arrays[key]
         for x in value:
             e.append(compose_element(e_key, x, arrays))
-    elif isinstance(value, collections.abc.Mapping):
+    elif isinstance(value, Mapping):
         for key, value in value.items():
             e.append(compose_element(key, value, arrays))
     else:

--- a/insales/connection.py
+++ b/insales/connection.py
@@ -7,16 +7,8 @@ import socket
 
 from base64 import b64encode
 
-try:
-    # Python 3
-    from urllib import parse as urlparse
-    from urllib.parse import urlencode
-    from http.client import HTTPConnection, HTTPSConnection, HTTPException
-except ImportError:
-    # Python 2
-    import urlparse
-    from httplib import HTTPConnection, HTTPSConnection, HTTPException
-    from urllib import urlencode
+from urllib import parse as urlparse
+from http.client import HTTPConnection, HTTPSConnection, HTTPException
 
 
 insales_lock = threading.Lock()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyinsales"
-version = "1.8.0"
+version = "1.8.1"
 description = """InSales e-commerce platform API bindings"""
 authors = [{name = "Victor Nakoryakov", email = "nail.xx@gmail.com"}]
 readme = "README.md"


### PR DESCRIPTION
Already contains fixes to work on modern versions of python from https://github.com/nkrkv/pyinsales/pull/26. Must have for https://github.com/amperka-hq/store-cms/pull/69.
Threw out compatibility with very old versions.
Version is already bumped. @nkrkv merge and release, please.

